### PR TITLE
Improve the tag interactions

### DIFF
--- a/Sources/SteamPress/Controllers/BlogAdminController.swift
+++ b/Sources/SteamPress/Controllers/BlogAdminController.swift
@@ -12,6 +12,7 @@ struct BlogAdminController {
     fileprivate let pathCreator: BlogPathCreator
     fileprivate let viewFactory: ViewFactory
 
+    
     // MARK: - Initialiser
     init(drop: Droplet, pathCreator: BlogPathCreator, viewFactory: ViewFactory) {
         self.drop = drop
@@ -87,7 +88,6 @@ struct BlogAdminController {
         // Save the tags
         for tagNode in tagsArray {
             if let tagName = tagNode.string {
-                print("Adding tag \(tagName) to blog post")
                 try BlogTag.addTag(tagName, to: newPost)
             }
         }
@@ -153,7 +153,6 @@ struct BlogAdminController {
 
         let existing = try post.tags()
         let existingStringArray = existing.map { $0.name }
-        
         let newTagsStringArray = tagsArray.map { $0.string ?? "" }.filter { $0 != "" }
 
         // Work out new tags and tags to delete

--- a/Sources/SteamPress/Controllers/BlogAdminController.swift
+++ b/Sources/SteamPress/Controllers/BlogAdminController.swift
@@ -12,7 +12,6 @@ struct BlogAdminController {
     fileprivate let pathCreator: BlogPathCreator
     fileprivate let viewFactory: ViewFactory
 
-    
     // MARK: - Initialiser
     init(drop: Droplet, pathCreator: BlogPathCreator, viewFactory: ViewFactory) {
         self.drop = drop
@@ -56,7 +55,7 @@ struct BlogAdminController {
     func createPostPostHandler(_ request: Request) throws -> ResponseRepresentable {
         let rawTitle = request.data["inputTitle"]?.string
         let rawContents = request.data["inputPostContents"]?.string
-        let rawTags = request.data["inputTags"]?.array //as? [Node] ?? (request.data["inputTags"]?.array as? [String]).map { $0.makeNode() } ?? []
+        let rawTags = request.data["inputTags"]?.array
         let rawSlugUrl = request.data["inputSlugUrl"]?.string
         
         // I must be able to inline all of this
@@ -475,7 +474,6 @@ struct BlogAdminController {
         }
 
         return createPostErrors
-
     }
 
     private func validateUserSaveDataExists(edit: Bool, name: String?, username: String?, password: String?, confirmPassword: String?) -> ([String]?, Bool?, Bool?) {
@@ -556,7 +554,6 @@ struct BlogAdminController {
         }
 
         return (userSaveErrors, passwordError, confirmPasswordError)
-
     }
 
 }

--- a/Sources/SteamPress/Controllers/BlogController.swift
+++ b/Sources/SteamPress/Controllers/BlogController.swift
@@ -9,6 +9,7 @@ struct BlogController {
     fileprivate let blogPostsPath = "posts"
     fileprivate let tagsPath = "tags"
     fileprivate let authorsPath = "authors"
+    fileprivate let apiPath = "api"
     fileprivate let drop: Droplet
     fileprivate let pathCreator: BlogPathCreator
     fileprivate let viewFactory: ViewFactory
@@ -29,6 +30,7 @@ struct BlogController {
             index.get(blogPostsPath, String.self, handler: blogPostHandler)
             index.get(tagsPath, String.self, handler: tagViewHandler)
             index.get(authorsPath, String.self, handler: authorViewHandler)
+            index.get(apiPath, tagsPath, handler: tagApiHandler)
         }
     }
     
@@ -70,6 +72,10 @@ struct BlogController {
         let posts = try author.posts()
         
         return try viewFactory.createProfileView(author: author, isMyProfile: false, posts: posts, loggedInUser: getLoggedInUser(in: request), disqusName: getDisqusName())
+    }
+    
+    func tagApiHandler(request: Request) throws -> ResponseRepresentable {
+        return try BlogTag.all().makeJSON()
     }
     
     private func getLoggedInUser(in request: Request) -> BlogUser? {

--- a/Sources/SteamPress/Views/LeafViewFactory.swift
+++ b/Sources/SteamPress/Views/LeafViewFactory.swift
@@ -9,7 +9,7 @@ struct LeafViewFactory: ViewFactory {
 
     // MARK: - Admin Controller Views
 
-    func createBlogPostView(uri: URI, errors: [String]? = nil, title: String? = nil, contents: String? = nil, slugUrl: String? = nil, tags: String? = nil, isEditing: Bool = false, postToEdit: BlogPost? = nil) throws -> View {
+    func createBlogPostView(uri: URI, errors: [String]? = nil, title: String? = nil, contents: String? = nil, slugUrl: String? = nil, tags: [Node]? = nil, isEditing: Bool = false, postToEdit: BlogPost? = nil) throws -> View {
         let titleError = (title == nil || (title?.isWhitespace())!) && errors != nil
         let contentsError = (contents == nil || (contents?.isWhitespace())!) && errors != nil
 
@@ -47,8 +47,8 @@ struct LeafViewFactory: ViewFactory {
             parameters["slugUrlSupplied"] = slugUrlSupplied.makeNode()
         }
 
-        if let tagsSupplied = tags {
-            parameters["tagsSupplied"] = tagsSupplied.makeNode()
+        if let tagsSupplied = tags, tagsSupplied.count > 0 {
+            parameters["tagsSupplied"] = try tagsSupplied.makeNode()
         }
 
         if isEditing {

--- a/Sources/SteamPress/Views/ViewFactory.swift
+++ b/Sources/SteamPress/Views/ViewFactory.swift
@@ -5,7 +5,7 @@ import Paginator
 protocol ViewFactory {
     
     // MARK: - Admin Controller
-    func createBlogPostView(uri: URI, errors: [String]?, title: String?, contents: String?, slugUrl: String?, tags: String?, isEditing: Bool, postToEdit: BlogPost?) throws -> View
+    func createBlogPostView(uri: URI, errors: [String]?, title: String?, contents: String?, slugUrl: String?, tags: [Node]?, isEditing: Bool, postToEdit: BlogPost?) throws -> View
     func createUserView(editing: Bool, errors: [String]?, name: String?, username: String?, passwordError: Bool?, confirmPasswordError: Bool?, resetPasswordRequired: Bool?, userId: Node?) throws -> View
     func createLoginView(loginWarning: Bool, errors: [String]?, username: String?, password: String?) throws -> View
     func createBlogAdminView(errors: [String]?) throws -> View

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,4 +5,5 @@ import XCTest
 XCTMain([
     testCase(BlogPostTests.allTests),
     testCase(BlogControllerTests.allTests),
+    testCase(BlogAdminControllerTests.allTests),
 ])

--- a/Tests/SteamPressTests/BlogAdminControllerTests.swift
+++ b/Tests/SteamPressTests/BlogAdminControllerTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Vapor
+@testable import SteamPress
+import HTTP
+import Fluent
+
+class BlogAdminControllerTests: XCTestCase {
+    static var allTests = [
+        ("testTagAPIEndpointReportsArrayOfTagsAsJson", testTagAPIEndpointReportsArrayOfTagsAsJson),
+    ]
+    
+    func testTagAPIEndpointReportsArrayOfTagsAsJson() throws {
+        var tag1 = BlogTag(name: "The first tag")
+        var tag2 = BlogTag(name: "The second tag")
+        
+        let drop = Droplet(arguments: ["dummy/path/", "prepare"], config: nil)
+        drop.database = Database(MemoryDriver())
+        let steampress = SteamPress.Provider(postsPerPage: 5)
+        steampress.setup(drop)
+        let pathCreator = BlogPathCreator(blogPath: nil)
+        // TODO change to Stub
+        let viewFactory = CapturingViewFactory()
+        let blogController = BlogController(drop: drop, pathCreator: pathCreator, viewFactory: viewFactory, postsPerPage: 5)
+        blogController.addRoutes()
+        try drop.runCommands()
+        
+        try tag1.save()
+        try tag2.save()
+        
+        let tagApiRequest = try! Request(method: .get, uri: "/api/tags/")
+        let response = try drop.respond(to: tagApiRequest)
+        
+        let tagsJson = try JSON(bytes: response.body.bytes!)
+        
+        XCTAssertNotNil(tagsJson.array)
+        XCTAssertEqual(tagsJson.array?.count, 2)
+        
+        guard let nodeArray = tagsJson.array as? [JSON] else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(nodeArray[0]["name"]?.string, "The first tag")
+        XCTAssertEqual(nodeArray[1]["name"]?.string, "The second tag")
+    }
+}

--- a/Tests/SteamPressTests/BlogControllerTests.swift
+++ b/Tests/SteamPressTests/BlogControllerTests.swift
@@ -193,7 +193,7 @@ import Paginator
 
 class CapturingViewFactory: ViewFactory {
     
-    func createBlogPostView(uri: URI, errors: [String]?, title: String?, contents: String?, slugUrl: String?, tags: String?, isEditing: Bool, postToEdit: BlogPost?) throws -> View {
+    func createBlogPostView(uri: URI, errors: [String]?, title: String?, contents: String?, slugUrl: String?, tags: [Node]?, isEditing: Bool, postToEdit: BlogPost?) throws -> View {
         return View(data: try "Test".makeBytes())
     }
     


### PR DESCRIPTION
This PR changes the way tags are applied to posts. It now accepts a `select` input of the different tags selected. This allows for any type of tags (with spaces etc) to be added and allows libraries such as Select2 to be used. It also adds an API endpoint for getting all of the tags