### PR TITLE
Ensure User is passed to all Leaf pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ The Twitter handle of the site can be configured with a `twitter.json` config fi
 
 SteamPress expects there to be a number of Leaf template files in the correct location in `Resources/Views`. All these files should be in a `blog` directory, with the admin template files being in an `admin` directory. For an example of how it SteamPress works with the leaf templates, see the [Example SteamPress site](https://github.com/brokenhandsio/SteamPressExample).
 
+For every Leaf template, a `user` parameter will be passed in for the currently logged in user, if there is a user currently logged in. This is useful for displaying a 'Create Post' link throughout the site when logged in etc.
+
 The basic structure of your `Resources/View` directory should be:
 
 * `blog`
@@ -205,7 +207,6 @@ This is the index page of the blog. The parameters it will receive are:
 * `posts` - a Node containing data about the posts and metadata for the paginator. You can access the posts by calling the `.data` object on it, which is an array of blog posts if there are any, in date descending order. The posts will be made with a `longSnippet` context (see below)
 * `tags` - an array of tags if there are any
 * `authors` - an array of the authors if there are any
-* `user` - the currently logged in user if a user is currently logged in
 * `disqus_name` - the name of your Disqus site if configured
 * `blog_index_page` - a boolean saying we are on the index page of the blog - useful for navbars
 * `site_twitter_handle` - the Twitter handle for the site if configured
@@ -219,7 +220,6 @@ This is the page for viewing a single entire blog post. The parameters set are:
 * `post` - the full current post, with the `all` context
 * `author` - the author of the post
 * `blog_post_page` - a boolean saying we are on the blog post page
-* `user` - the currently logged in user if a user is currently logged in
 * `disqus_name` - the name of your Disqus site if configured
 * `post_uri` - The URI of the post
 * `post_uri_encoded` - A URL-query encoded for of the URI for passing to Share buttons
@@ -236,7 +236,6 @@ This is the page for a tag. A blog post can be tagged with many tags and a tag c
 * `tag` - the tag
 * `posts` - a Node containing data about the posts and metadata for the paginator. You can access the posts by calling the `.data` object on it, which is an array of blog posts if there are any, in date descending order. The posts will be made with a `longSnippet` context (see below)
 * `tag_page` - a boolean saying we are on the tag page
-* `user` - the currently logged in user if a user is currently logged in
 * `disqus_name` - the name of your Disqus site if configured
 * `site_twitter_handle` - the Twitter handle for the site if configured
 * `uri` - the URI of the page - useful for Open Graph
@@ -248,7 +247,6 @@ This is the page for viewing a profile of a user. This is generally used for vie
 * `author` - the user the page is for
 * `profile_page` - a boolean set to to true if we are viewing the profile page
 * `posts` - all the posts the user has written if they have written any in `shortSnippet` form
-* `user` - the currently logged in user if a user is currently logged in
 * `disqus_name` - the name of your Disqus site if configured
 * `site_twitter_handle` - the Twitter handle for the site if configured
 * `uri` - the URI of the page - useful for Open Graph
@@ -258,7 +256,6 @@ This is the page for viewing a profile of a user. This is generally used for vie
 This is the page for viewing all of the tags on the blog. This provides some more navigation points for the blog as well as providing a page in case the user strips off the tag from the Tag's URL. The parameters that can be passed to it are:
 
 * `tags` - an array of all the tags on the blog, in `withPostCount` context (see below) sorted by post count
-* `user` - the currently logged in user if a user is currently logged in
 * `site_twitter_handle` - the Twitter handle for the site if configured
 * `uri` - the URI of the page - useful for Open Graph
 
@@ -267,7 +264,6 @@ This is the page for viewing all of the tags on the blog. This provides some mor
 This is the page for viewing all of the authors on the blog. It provides a useful page for user's to see everyone who has contributed to the site.
 
 * `authors` - an array of all the `BlogUser`s on the blog, in `withPostCount` context (see below) sorted by post count
-* `user` - the currently logged in user if a user is currently logged in
 * `site_twitter_handle` - the Twitter handle for the site if configured
 * `uri` - the URI of the page - useful for Open Graph
 

--- a/Sources/SteamPress/Controllers/BlogAdminController.swift
+++ b/Sources/SteamPress/Controllers/BlogAdminController.swift
@@ -378,7 +378,7 @@ struct BlogAdminController {
 
     // MARK: - Password handlers
     func resetPasswordHandler(_ request: Request) throws -> ResponseRepresentable {
-        return try viewFactory.createResetPasswordView(errors: nil, passwordError: nil, confirmPasswordError: nil)
+        return try viewFactory.createResetPasswordView(errors: nil, passwordError: nil, confirmPasswordError: nil, user: request.user())
     }
 
     func resetPasswordPostHandler(_ request: Request) throws -> ResponseRepresentable {
@@ -400,7 +400,7 @@ struct BlogAdminController {
             }
 
             // Return if we have any missing fields
-            return try viewFactory.createResetPasswordView(errors: resetPasswordErrors, passwordError: passwordError, confirmPasswordError: confirmPasswordError)
+            return try viewFactory.createResetPasswordView(errors: resetPasswordErrors, passwordError: passwordError, confirmPasswordError: confirmPasswordError, user: request.user())
         }
 
         if password != confirmPassword {
@@ -417,7 +417,7 @@ struct BlogAdminController {
         }
 
         if !resetPasswordErrors.isEmpty {
-            return try viewFactory.createResetPasswordView(errors: resetPasswordErrors, passwordError: passwordError, confirmPasswordError: confirmPasswordError)
+            return try viewFactory.createResetPasswordView(errors: resetPasswordErrors, passwordError: passwordError, confirmPasswordError: confirmPasswordError, user: request.user())
         }
 
         let user = try request.user()

--- a/Sources/SteamPress/Controllers/BlogAdminController.swift
+++ b/Sources/SteamPress/Controllers/BlogAdminController.swift
@@ -193,7 +193,7 @@ struct BlogAdminController {
 
     // MARK: - User handlers
     func createUserHandler(_ request: Request) throws -> ResponseRepresentable {
-        return try viewFactory.createUserView(editing: false, errors: nil, name: nil, username: nil, passwordError: nil, confirmPasswordError: nil, resetPasswordRequired: nil, userId: nil, profilePicture: nil, twitterHandle: nil, biography: nil, tagline: nil)
+        return try viewFactory.createUserView(editing: false, errors: nil, name: nil, username: nil, passwordError: nil, confirmPasswordError: nil, resetPasswordRequired: nil, userId: nil, profilePicture: nil, twitterHandle: nil, biography: nil, tagline: nil, loggedInUser: request.user())
     }
 
     func createUserPostHandler(_ request: Request) throws -> ResponseRepresentable {
@@ -213,7 +213,7 @@ struct BlogAdminController {
 
         // Return if we have any missing fields
         if !(createUserRawErrors?.isEmpty ?? true) {
-            return try viewFactory.createUserView(editing: false, errors: createUserRawErrors, name: rawName, username: rawUsername, passwordError: passwordRawError, confirmPasswordError: confirmPasswordRawError, resetPasswordRequired: resetPasswordRequired, userId: nil, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline)
+            return try viewFactory.createUserView(editing: false, errors: createUserRawErrors, name: rawName, username: rawUsername, passwordError: passwordRawError, confirmPasswordError: confirmPasswordRawError, resetPasswordRequired: resetPasswordRequired, userId: nil, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline, loggedInUser: request.user())
         }
 
         guard let name = rawName, let username = rawUsername?.lowercased(), let password = rawPassword, let confirmPassword = rawConfirmPassword else {
@@ -223,7 +223,7 @@ struct BlogAdminController {
         let (createUserErrors, passwordError, confirmPasswordError) = validateUserSaveData(edit: false, name: name, username: username, password: password, confirmPassword: confirmPassword)
 
         if !(createUserErrors?.isEmpty ?? true) {
-            return try viewFactory.createUserView(editing: false, errors: createUserErrors, name: name, username: username, passwordError: passwordError, confirmPasswordError: confirmPasswordError, resetPasswordRequired: resetPasswordRequired, userId: nil, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline)
+            return try viewFactory.createUserView(editing: false, errors: createUserErrors, name: name, username: username, passwordError: passwordError, confirmPasswordError: confirmPasswordError, resetPasswordRequired: resetPasswordRequired, userId: nil, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline, loggedInUser: request.user())
         }
 
         // We now have valid data
@@ -237,7 +237,7 @@ struct BlogAdminController {
         do {
             try newUser.save()
         } catch {
-            return try viewFactory.createUserView(editing: false, errors: ["There was an error creating the user. Please try again"], name: name, username: username, passwordError: passwordError, confirmPasswordError: confirmPasswordError, resetPasswordRequired: resetPasswordRequired, userId: nil, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline)
+            return try viewFactory.createUserView(editing: false, errors: ["There was an error creating the user. Please try again"], name: name, username: username, passwordError: passwordError, confirmPasswordError: confirmPasswordError, resetPasswordRequired: resetPasswordRequired, userId: nil, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline, loggedInUser: request.user())
         }
 
         return Response(redirect: pathCreator.createPath(for: "admin"))
@@ -246,7 +246,7 @@ struct BlogAdminController {
 
     func editUserHandler(request: Request) throws -> ResponseRepresentable {
         let user = try request.parameters.next(BlogUser.self)
-        return try viewFactory.createUserView(editing: true, errors: nil, name: user.name, username: user.username, passwordError: nil, confirmPasswordError: nil, resetPasswordRequired: nil, userId: user.id, profilePicture: user.profilePicture, twitterHandle: user.twitterHandle, biography: user.biography, tagline: user.tagline)
+        return try viewFactory.createUserView(editing: true, errors: nil, name: user.name, username: user.username, passwordError: nil, confirmPasswordError: nil, resetPasswordRequired: nil, userId: user.id, profilePicture: user.profilePicture, twitterHandle: user.twitterHandle, biography: user.biography, tagline: user.tagline, loggedInUser: request.user())
     }
 
     func editUserPostHandler(request: Request) throws -> ResponseRepresentable {
@@ -266,7 +266,7 @@ struct BlogAdminController {
 
         // Return if we have any missing fields
         if !(saveUserRawErrors?.isEmpty ?? true) {
-            return try viewFactory.createUserView(editing: true, errors: saveUserRawErrors, name: rawName, username: rawUsername, passwordError: passwordRawError, confirmPasswordError: confirmPasswordRawError, resetPasswordRequired: resetPasswordRequired, userId: user.id, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline)
+            return try viewFactory.createUserView(editing: true, errors: saveUserRawErrors, name: rawName, username: rawUsername, passwordError: passwordRawError, confirmPasswordError: confirmPasswordRawError, resetPasswordRequired: resetPasswordRequired, userId: user.id, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline, loggedInUser: request.user())
         }
 
         guard let name = rawName, let username = rawUsername else {
@@ -276,7 +276,7 @@ struct BlogAdminController {
         let (saveUserErrors, passwordError, confirmPasswordError) = validateUserSaveData(edit: true, name: name, username: username, password: rawPassword, confirmPassword: rawConfirmPassword, previousUsername: user.username)
 
         if !(saveUserErrors?.isEmpty ?? true) {
-            return try viewFactory.createUserView(editing: true, errors: saveUserErrors, name: name, username: username, passwordError: passwordError, confirmPasswordError: confirmPasswordError, resetPasswordRequired: resetPasswordRequired, userId: user.id, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline)
+            return try viewFactory.createUserView(editing: true, errors: saveUserErrors, name: name, username: username, passwordError: passwordError, confirmPasswordError: confirmPasswordError, resetPasswordRequired: resetPasswordRequired, userId: user.id, profilePicture: profilePicture, twitterHandle: twitterHandle, biography: biography, tagline: tagline, loggedInUser: request.user())
         }
 
         // We now have valid data

--- a/Sources/SteamPress/Controllers/BlogAdminController.swift
+++ b/Sources/SteamPress/Controllers/BlogAdminController.swift
@@ -307,11 +307,11 @@ struct BlogAdminController {
         // Check we have at least one user left
         let users = try BlogUser.all()
         if users.count <= 1 {
-            return try viewFactory.createBlogAdminView(errors: ["You cannot delete the last user"])
+            return try viewFactory.createBlogAdminView(errors: ["You cannot delete the last user"], user: try request.user())
         }
         // Make sure we aren't deleting ourselves!
         else if try request.user().id == user.id {
-            return try viewFactory.createBlogAdminView(errors: ["You cannot delete yourself whilst logged in"])
+            return try viewFactory.createBlogAdminView(errors: ["You cannot delete yourself whilst logged in"], user: try request.user())
         } else {
             try user.delete()
             return Response(redirect: pathCreator.createPath(for: "admin"))
@@ -373,7 +373,7 @@ struct BlogAdminController {
 
     // MARK: Admin Handler
     func adminHandler(_ request: Request) throws -> ResponseRepresentable {
-        return try viewFactory.createBlogAdminView(errors: nil)
+        return try viewFactory.createBlogAdminView(errors: nil, user: try request.user())
     }
 
     // MARK: - Password handlers

--- a/Sources/SteamPress/Controllers/BlogAdminController.swift
+++ b/Sources/SteamPress/Controllers/BlogAdminController.swift
@@ -52,7 +52,7 @@ struct BlogAdminController {
 
     // MARK: - Blog Posts handlers
     func createPostHandler(_ request: Request) throws -> ResponseRepresentable {
-        return try viewFactory.createBlogPostView(uri: request.uri, errors: nil, title: nil, contents: nil, slugUrl: nil, tags: nil, isEditing: false, postToEdit: nil, draft: true)
+        return try viewFactory.createBlogPostView(uri: request.uri, errors: nil, title: nil, contents: nil, slugUrl: nil, tags: nil, isEditing: false, postToEdit: nil, draft: true, user: try request.user())
     }
 
     func createPostPostHandler(_ request: Request) throws -> ResponseRepresentable {
@@ -70,7 +70,7 @@ struct BlogAdminController {
         let tagsArray = rawTags?.array ?? [rawTags?.string?.makeNode(in: nil) ?? nil]
 
         if let createPostErrors = validatePostCreation(title: rawTitle, contents: rawContents, slugUrl: rawSlugUrl) {
-            return try viewFactory.createBlogPostView(uri: request.uri, errors: createPostErrors, title: rawTitle, contents: rawContents, slugUrl: rawSlugUrl, tags: rawTags?.array, isEditing: false, postToEdit: nil, draft: true)
+            return try viewFactory.createBlogPostView(uri: request.uri, errors: createPostErrors, title: rawTitle, contents: rawContents, slugUrl: rawSlugUrl, tags: rawTags?.array, isEditing: false, postToEdit: nil, draft: true, user: try request.user())
         }
 
         guard let title = rawTitle, let contents = rawContents, var slugUrl = rawSlugUrl else {
@@ -124,7 +124,7 @@ struct BlogAdminController {
         let post = try request.parameters.next(BlogPost.self)
         let tags = try post.tags.all()
         let tagsArray: [Node] = tags.map { $0.name.makeNode(in: nil) }
-        return try viewFactory.createBlogPostView(uri: request.uri, errors: nil, title: post.title, contents: post.contents, slugUrl: post.slugUrl, tags: tagsArray, isEditing: true, postToEdit: post, draft: !post.published)
+        return try viewFactory.createBlogPostView(uri: request.uri, errors: nil, title: post.title, contents: post.contents, slugUrl: post.slugUrl, tags: tagsArray, isEditing: true, postToEdit: post, draft: !post.published, user: try request.user())
     }
 
     func editPostPostHandler(request: Request) throws -> ResponseRepresentable {
@@ -138,7 +138,7 @@ struct BlogAdminController {
         let tagsArray = rawTags?.array ?? [rawTags?.string?.makeNode(in: nil) ?? nil]
 
         if let errors = validatePostCreation(title: rawTitle, contents: rawContents, slugUrl: rawSlugUrl) {
-            return try viewFactory.createBlogPostView(uri: request.uri, errors: errors, title: rawTitle, contents: rawContents, slugUrl: rawSlugUrl, tags: tagsArray, isEditing: true, postToEdit: post, draft: false)
+            return try viewFactory.createBlogPostView(uri: request.uri, errors: errors, title: rawTitle, contents: rawContents, slugUrl: rawSlugUrl, tags: tagsArray, isEditing: true, postToEdit: post, draft: false, user: try request.user())
         }
 
         guard let title = rawTitle, let contents = rawContents, let slugUrl = rawSlugUrl else {

--- a/Sources/SteamPress/Controllers/BlogController.swift
+++ b/Sources/SteamPress/Controllers/BlogController.swift
@@ -97,7 +97,7 @@ struct BlogController {
 
         let posts = try author.sortedPosts().paginate(for: request)
 
-        return try viewFactory.createProfileView(uri: request.uri, author: author, paginatedPosts: posts, loggedInUser: getLoggedInUser(in: request))
+        return try viewFactory.profileView(uri: request.uri, author: author, paginatedPosts: posts, loggedInUser: getLoggedInUser(in: request))
     }
 
     func allTagsViewHandler(request: Request) throws -> ResponseRepresentable {

--- a/Sources/SteamPress/Views/LeafViewFactory.swift
+++ b/Sources/SteamPress/Views/LeafViewFactory.swift
@@ -72,13 +72,14 @@ struct LeafViewFactory: ViewFactory {
         return try viewRenderer.make("blog/admin/createPost", parameters)
     }
 
-    func createUserView(editing: Bool = false, errors: [String]? = nil, name: String? = nil, username: String? = nil, passwordError: Bool? = nil, confirmPasswordError: Bool? = nil, resetPasswordRequired: Bool? = nil, userId: Identifier? = nil, profilePicture: String? = nil, twitterHandle: String? = nil, biography: String? = nil, tagline: String? = nil) throws -> View {
+    func createUserView(editing: Bool = false, errors: [String]? = nil, name: String? = nil, username: String? = nil, passwordError: Bool? = nil, confirmPasswordError: Bool? = nil, resetPasswordRequired: Bool? = nil, userId: Identifier? = nil, profilePicture: String? = nil, twitterHandle: String? = nil, biography: String? = nil, tagline: String? = nil, loggedInUser: BlogUser) throws -> View {
         let nameError = name == nil && errors != nil
         let usernameError = username == nil && errors != nil
 
         var parameters: [String: NodeRepresentable] = [:]
         parameters["name_error"] = nameError
         parameters["username_error"] = usernameError
+        parameters["user"] = loggedInUser
 
         if let createUserErrors = errors {
             parameters["errors"] = try createUserErrors.makeNode(in: nil)

--- a/Sources/SteamPress/Views/LeafViewFactory.swift
+++ b/Sources/SteamPress/Views/LeafViewFactory.swift
@@ -153,14 +153,14 @@ struct LeafViewFactory: ViewFactory {
         return try viewRenderer.make("blog/admin/login", parameters)
     }
 
-    func createBlogAdminView(errors: [String]? = nil) throws -> View {
+    func createBlogAdminView(errors: [String]? = nil, user: BlogUser) throws -> View {
         let publishedBlogPosts = try BlogPost.makeQuery().filter(BlogPost.Properties.published, true).sort(BlogPost.Properties.created, .descending).all()
         let draftBlogPosts = try BlogPost.makeQuery().filter(BlogPost.Properties.published, false).sort(BlogPost.Properties.created, .descending).all()
         let users = try BlogUser.all()
 
         var parameters: [String: Vapor.Node] = [:]
-        parameters["users"] = try users.makeNode(in: nil
-        )
+        parameters["users"] = try users.makeNode(in: nil)
+        parameters["user"] = try user.makeNode(in: nil)
 
         if !publishedBlogPosts.isEmpty {
             parameters["published_posts"] = try publishedBlogPosts.makeNode(in: BlogPostContext.all)

--- a/Sources/SteamPress/Views/LeafViewFactory.swift
+++ b/Sources/SteamPress/Views/LeafViewFactory.swift
@@ -181,9 +181,10 @@ struct LeafViewFactory: ViewFactory {
         return try viewRenderer.make("blog/admin/index", parameters)
     }
 
-    func createResetPasswordView(errors: [String]? = nil, passwordError: Bool? = nil, confirmPasswordError: Bool? = nil) throws -> View {
+    func createResetPasswordView(errors: [String]? = nil, passwordError: Bool? = nil, confirmPasswordError: Bool? = nil, user: BlogUser) throws -> View {
 
         var parameters: [String: Vapor.Node] = [:]
+        parameters["user"] = try user.makeNode(in: nil)
 
         if let resetPasswordErrors = errors {
             parameters["errors"] = try resetPasswordErrors.makeNode(in: nil)

--- a/Sources/SteamPress/Views/ViewFactory.swift
+++ b/Sources/SteamPress/Views/ViewFactory.swift
@@ -11,7 +11,7 @@ protocol ViewFactory {
     func createUserView(editing: Bool, errors: [String]?, name: String?, username: String?, passwordError: Bool?,
                         confirmPasswordError: Bool?, resetPasswordRequired: Bool?, userId: Identifier?,
                         profilePicture: String?, twitterHandle: String?, biography: String?,
-                        tagline: String?) throws -> View
+                        tagline: String?, loggedInUser: BlogUser) throws -> View
     func createLoginView(loginWarning: Bool, errors: [String]?, username: String?, password: String?) throws -> View
     func createBlogAdminView(errors: [String]?, user: BlogUser) throws -> View
     func createResetPasswordView(errors: [String]?, passwordError: Bool?, confirmPasswordError: Bool?) throws -> View

--- a/Sources/SteamPress/Views/ViewFactory.swift
+++ b/Sources/SteamPress/Views/ViewFactory.swift
@@ -7,7 +7,7 @@ protocol ViewFactory {
 
     // MARK: - Admin Controller
     func createBlogPostView(uri: URI, errors: [String]?, title: String?, contents: String?, slugUrl: String?,
-                            tags: [Node]?, isEditing: Bool, postToEdit: BlogPost?, draft: Bool) throws -> View
+                            tags: [Node]?, isEditing: Bool, postToEdit: BlogPost?, draft: Bool, user: BlogUser) throws -> View
     func createUserView(editing: Bool, errors: [String]?, name: String?, username: String?, passwordError: Bool?,
                         confirmPasswordError: Bool?, resetPasswordRequired: Bool?, userId: Identifier?,
                         profilePicture: String?, twitterHandle: String?, biography: String?,
@@ -15,8 +15,6 @@ protocol ViewFactory {
     func createLoginView(loginWarning: Bool, errors: [String]?, username: String?, password: String?) throws -> View
     func createBlogAdminView(errors: [String]?, user: BlogUser) throws -> View
     func createResetPasswordView(errors: [String]?, passwordError: Bool?, confirmPasswordError: Bool?) throws -> View
-    func createProfileView(uri: URI, author: BlogUser,
-                           paginatedPosts: Page<BlogPost>, loggedInUser: BlogUser?) throws -> View
 
     // MARK: - Blog Controller
     func blogIndexView(uri: URI, paginatedPosts: Page<BlogPost>, tags: [BlogTag],
@@ -25,4 +23,5 @@ protocol ViewFactory {
     func tagView(uri: URI, tag: BlogTag, paginatedPosts: Page<BlogPost>, user: BlogUser?) throws -> View
     func allAuthorsView(uri: URI, allAuthors: [BlogUser], user: BlogUser?) throws -> View
     func allTagsView(uri: URI, allTags: [BlogTag], user: BlogUser?) throws -> View
+    func profileView(uri: URI, author: BlogUser, paginatedPosts: Page<BlogPost>, loggedInUser: BlogUser?) throws -> View
 }

--- a/Sources/SteamPress/Views/ViewFactory.swift
+++ b/Sources/SteamPress/Views/ViewFactory.swift
@@ -13,7 +13,7 @@ protocol ViewFactory {
                         profilePicture: String?, twitterHandle: String?, biography: String?,
                         tagline: String?) throws -> View
     func createLoginView(loginWarning: Bool, errors: [String]?, username: String?, password: String?) throws -> View
-    func createBlogAdminView(errors: [String]?) throws -> View
+    func createBlogAdminView(errors: [String]?, user: BlogUser) throws -> View
     func createResetPasswordView(errors: [String]?, passwordError: Bool?, confirmPasswordError: Bool?) throws -> View
     func createProfileView(uri: URI, author: BlogUser,
                            paginatedPosts: Page<BlogPost>, loggedInUser: BlogUser?) throws -> View

--- a/Sources/SteamPress/Views/ViewFactory.swift
+++ b/Sources/SteamPress/Views/ViewFactory.swift
@@ -14,7 +14,7 @@ protocol ViewFactory {
                         tagline: String?, loggedInUser: BlogUser) throws -> View
     func createLoginView(loginWarning: Bool, errors: [String]?, username: String?, password: String?) throws -> View
     func createBlogAdminView(errors: [String]?, user: BlogUser) throws -> View
-    func createResetPasswordView(errors: [String]?, passwordError: Bool?, confirmPasswordError: Bool?) throws -> View
+    func createResetPasswordView(errors: [String]?, passwordError: Bool?, confirmPasswordError: Bool?, user: BlogUser) throws -> View
 
     // MARK: - Blog Controller
     func blogIndexView(uri: URI, paginatedPosts: Page<BlogPost>, tags: [BlogTag],

--- a/Tests/SteamPressTests/BlogAdminControllerTests.swift
+++ b/Tests/SteamPressTests/BlogAdminControllerTests.swift
@@ -64,6 +64,7 @@ class BlogAdminControllerTests: XCTestCase {
         ("testUserCanBeUpdated", testUserCanBeUpdated),
         ("testAdminPageGetsLoggedInUser", testAdminPageGetsLoggedInUser),
         ("testCreatePostPageGetsLoggedInUser", testCreatePostPageGetsLoggedInUser),
+        ("testEditPostPageGetsLoggedInUser", testEditPostPageGetsLoggedInUser),
     ]
     
     // MARK: - Properties
@@ -799,6 +800,17 @@ class BlogAdminControllerTests: XCTestCase {
     
     func testCreatePostPageGetsLoggedInUser() throws {
         let request = try createLoggedInRequest(method: .get, path: "createPost", for: user)
+        _ = try drop.respond(to: request)
+        
+        XCTAssertEqual(user.name, capturingViewFactory.createBlogPostUser?.name)
+    }
+    
+    func testEditPostPageGetsLoggedInUser() throws {
+        let user = TestDataBuilder.anyUser()
+        try user.save()
+        let post = TestDataBuilder.anyPost(author: user)
+        try post.save()
+        let request = try createLoggedInRequest(method: .get, path: "posts/\(post.id!.string!)/edit", for: user)
         _ = try drop.respond(to: request)
         
         XCTAssertEqual(user.name, capturingViewFactory.createBlogPostUser?.name)

--- a/Tests/SteamPressTests/BlogAdminControllerTests.swift
+++ b/Tests/SteamPressTests/BlogAdminControllerTests.swift
@@ -63,6 +63,7 @@ class BlogAdminControllerTests: XCTestCase {
         ("testPostCanBeUpdated", testPostCanBeUpdated),
         ("testUserCanBeUpdated", testUserCanBeUpdated),
         ("testAdminPageGetsLoggedInUser", testAdminPageGetsLoggedInUser),
+        ("testCreatePostPageGetsLoggedInUser", testCreatePostPageGetsLoggedInUser),
     ]
     
     // MARK: - Properties
@@ -794,6 +795,13 @@ class BlogAdminControllerTests: XCTestCase {
         _ = try drop.respond(to: request)
         
         XCTAssertEqual(user.name, capturingViewFactory.adminUser?.name)
+    }
+    
+    func testCreatePostPageGetsLoggedInUser() throws {
+        let request = try createLoggedInRequest(method: .get, path: "createPost", for: user)
+        _ = try drop.respond(to: request)
+        
+        XCTAssertEqual(user.name, capturingViewFactory.createBlogPostUser?.name)
     }
     
     // MARK: - Helper functions

--- a/Tests/SteamPressTests/BlogAdminControllerTests.swift
+++ b/Tests/SteamPressTests/BlogAdminControllerTests.swift
@@ -67,6 +67,7 @@ class BlogAdminControllerTests: XCTestCase {
         ("testEditPostPageGetsLoggedInUser", testEditPostPageGetsLoggedInUser),
         ("testCreateUserPageGetsLoggedInUser", testCreatePostPageGetsLoggedInUser),
         ("testEditUserPageGetsLoggedInUser", testEditPostPageGetsLoggedInUser),
+        ("testResetPasswordPageGetsLoggedInUser", testResetPasswordPageGetsLoggedInUser),
     ]
     
     // MARK: - Properties
@@ -832,6 +833,13 @@ class BlogAdminControllerTests: XCTestCase {
         _ = try drop.respond(to: request)
         
         XCTAssertEqual(user.name, capturingViewFactory.createUserLoggedInUser?.name)
+    }
+    
+    func testResetPasswordPageGetsLoggedInUser() throws {
+        let request = try createLoggedInRequest(method: .get, path: "resetPassword", for: user)
+        _ = try drop.respond(to: request)
+        
+        XCTAssertEqual(user.name, capturingViewFactory.resetPasswordUser?.name)
     }
     
     // MARK: - Helper functions

--- a/Tests/SteamPressTests/BlogAdminControllerTests.swift
+++ b/Tests/SteamPressTests/BlogAdminControllerTests.swift
@@ -65,6 +65,8 @@ class BlogAdminControllerTests: XCTestCase {
         ("testAdminPageGetsLoggedInUser", testAdminPageGetsLoggedInUser),
         ("testCreatePostPageGetsLoggedInUser", testCreatePostPageGetsLoggedInUser),
         ("testEditPostPageGetsLoggedInUser", testEditPostPageGetsLoggedInUser),
+        ("testCreateUserPageGetsLoggedInUser", testCreatePostPageGetsLoggedInUser),
+        ("testEditUserPageGetsLoggedInUser", testEditPostPageGetsLoggedInUser),
     ]
     
     // MARK: - Properties
@@ -814,6 +816,22 @@ class BlogAdminControllerTests: XCTestCase {
         _ = try drop.respond(to: request)
         
         XCTAssertEqual(user.name, capturingViewFactory.createBlogPostUser?.name)
+    }
+    
+    func testCreateUserPageGetsLoggedInUser() throws {
+        let request = try createLoggedInRequest(method: .get, path: "createUser", for: user)
+        _ = try drop.respond(to: request)
+        
+        XCTAssertEqual(user.name, capturingViewFactory.createUserLoggedInUser?.name)
+    }
+    
+    func testEditUserPageGetsLoggedInUser() throws {
+        let user = TestDataBuilder.anyUser()
+        try user.save()
+        let request = try createLoggedInRequest(method: .get, path: "users/\(user.id!.string!)/edit", for: user)
+        _ = try drop.respond(to: request)
+        
+        XCTAssertEqual(user.name, capturingViewFactory.createUserLoggedInUser?.name)
     }
     
     // MARK: - Helper functions

--- a/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
+++ b/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
@@ -19,8 +19,10 @@ class CapturingViewFactory: ViewFactory {
     }
     
     private(set) var createUserErrors: [String]? = nil
-    func createUserView(editing: Bool, errors: [String]?, name: String?, username: String?, passwordError: Bool?, confirmPasswordError: Bool?, resetPasswordRequired: Bool?, userId: Identifier?, profilePicture: String?, twitterHandle: String?, biography: String?, tagline: String?) throws -> View {
+    private(set) var createUserLoggedInUser: BlogUser?
+    func createUserView(editing: Bool, errors: [String]?, name: String?, username: String?, passwordError: Bool?, confirmPasswordError: Bool?, resetPasswordRequired: Bool?, userId: Identifier?, profilePicture: String?, twitterHandle: String?, biography: String?, tagline: String?, loggedInUser: BlogUser) throws -> View {
         self.createUserErrors = errors
+        self.createUserLoggedInUser = loggedInUser
         return createDummyView()
     }
     

--- a/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
+++ b/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
@@ -41,10 +41,12 @@ class CapturingViewFactory: ViewFactory {
     private(set) var resetPasswordErrors: [String]? = nil
     private(set) var resetPasswordErrorFlag: Bool? = nil
     private(set) var resetPasswordConfirmErrorFlag: Bool? = nil
-    func createResetPasswordView(errors: [String]?, passwordError: Bool?, confirmPasswordError: Bool?) throws -> View {
+    private(set) var resetPasswordUser: BlogUser?
+    func createResetPasswordView(errors: [String]?, passwordError: Bool?, confirmPasswordError: Bool?, user: BlogUser) throws -> View {
         self.resetPasswordErrors = errors
         self.resetPasswordErrorFlag = passwordError
         self.resetPasswordConfirmErrorFlag = confirmPasswordError
+        self.resetPasswordUser = user
         return createDummyView()
     }
     

--- a/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
+++ b/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
@@ -11,8 +11,10 @@ class CapturingViewFactory: ViewFactory {
     }
     
     private(set) var createPostErrors: [String]? = nil
-    func createBlogPostView(uri: URI, errors: [String]?, title: String?, contents: String?, slugUrl: String?, tags: [Node]?, isEditing: Bool, postToEdit: BlogPost?, draft: Bool) throws -> View {
+    private(set) var createBlogPostUser: BlogUser?
+    func createBlogPostView(uri: URI, errors: [String]?, title: String?, contents: String?, slugUrl: String?, tags: [Node]?, isEditing: Bool, postToEdit: BlogPost?, draft: Bool, user: BlogUser) throws -> View {
         self.createPostErrors = errors
+        self.createBlogPostUser = user
         return createDummyView()
     }
     
@@ -47,7 +49,7 @@ class CapturingViewFactory: ViewFactory {
     private(set) var author: BlogUser? = nil
     private(set) var authorPosts: Page<BlogPost>? = nil
     private(set) var authorURI: URI? = nil
-    func createProfileView(uri: URI, author: BlogUser, paginatedPosts: Page<BlogPost>, loggedInUser: BlogUser?) throws -> View {
+    func profileView(uri: URI, author: BlogUser, paginatedPosts: Page<BlogPost>, loggedInUser: BlogUser?) throws -> View {
         self.author = author
         self.authorPosts = paginatedPosts
         self.authorURI = uri

--- a/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
+++ b/Tests/SteamPressTests/Fakes/CapturingViewFactory.swift
@@ -27,7 +27,9 @@ class CapturingViewFactory: ViewFactory {
     }
     
     private(set) var adminViewErrors: [String]? = nil
-    func createBlogAdminView(errors: [String]?) throws -> View {
+    private(set) var adminUser: BlogUser? = nil
+    func createBlogAdminView(errors: [String]?, user: BlogUser) throws -> View {
+        adminUser = user
         adminViewErrors = errors
         return createDummyView()
     }

--- a/Tests/SteamPressTests/LeafViewFactoryTests.swift
+++ b/Tests/SteamPressTests/LeafViewFactoryTests.swift
@@ -481,20 +481,24 @@ class LeafViewFactoryTests: XCTestCase {
     // MARK: - Admin pages
     
     func testPasswordViewGivenCorrectParameters() throws {
-        let _ = try viewFactory.createResetPasswordView(errors: nil, passwordError: nil, confirmPasswordError: nil)
+        let user = TestDataBuilder.anyUser()
+        let _ = try viewFactory.createResetPasswordView(errors: nil, passwordError: nil, confirmPasswordError: nil, user: user)
         XCTAssertNil(viewRenderer.capturedContext?["errors"])
         XCTAssertNil(viewRenderer.capturedContext?["password_error"])
         XCTAssertNil(viewRenderer.capturedContext?["confirm_password_error"])
+        XCTAssertEqual(viewRenderer.capturedContext?["user"]?["name"]?.string, user.name)
         XCTAssertEqual(viewRenderer.leafPath, "blog/admin/resetPassword")
     }
     
     func testPasswordViewHasCorrectParametersWhenError() throws {
+        let user = TestDataBuilder.anyUser()
         let expectedError = "Passwords do not match"
-        let _ = try viewFactory.createResetPasswordView(errors: [expectedError], passwordError: true, confirmPasswordError: true)
+        let _ = try viewFactory.createResetPasswordView(errors: [expectedError], passwordError: true, confirmPasswordError: true, user: user)
         XCTAssertEqual(viewRenderer.capturedContext?["errors"]?.array?.count, 1)
         XCTAssertEqual((viewRenderer.capturedContext?["errors"]?.array?.first)?.string, expectedError)
         XCTAssertTrue((viewRenderer.capturedContext?["password_error"]?.bool) ?? false)
         XCTAssertTrue((viewRenderer.capturedContext?["confirm_password_error"]?.bool) ?? false)
+        XCTAssertEqual(viewRenderer.capturedContext?["user"]?["name"]?.string, user.name)
     }
     
     func testLoginViewGetsCorrectParameters() throws {

--- a/Tests/SteamPressTests/LeafViewFactoryTests.swift
+++ b/Tests/SteamPressTests/LeafViewFactoryTests.swift
@@ -529,9 +529,10 @@ class LeafViewFactoryTests: XCTestCase {
         let (posts, _, users) = try setupBlogIndex()
         let draftPost = TestDataBuilder.anyPost(author: users.first!, title: "[DRAFT] This will be awesome", published: false)
         try draftPost.save()
-        let _ = try viewFactory.createBlogAdminView()
+        let _ = try viewFactory.createBlogAdminView(user: TestDataBuilder.anyUser())
         XCTAssertNil(viewRenderer.capturedContext?["errors"])
         XCTAssertTrue((viewRenderer.capturedContext?["blog_admin_page"]?.bool) ?? false)
+        XCTAssertEqual(viewRenderer.capturedContext?["user"]?["name"]?.string, users.first?.name)
         XCTAssertEqual(viewRenderer.capturedContext?["users"]?.array?.count, 2)
         XCTAssertEqual(viewRenderer.capturedContext?["users"]?.array?.first?["name"]?.string, users.first?.name)
         XCTAssertEqual(viewRenderer.capturedContext?["published_posts"]?.array?.count, 2)
@@ -542,13 +543,13 @@ class LeafViewFactoryTests: XCTestCase {
     }
     
     func testNoPostsPassedToAdminViewIfNone() throws {
-        let _ = try viewFactory.createBlogAdminView()
+        let _ = try viewFactory.createBlogAdminView(user: TestDataBuilder.anyUser())
         XCTAssertNil(viewRenderer.capturedContext?["posts"])
     }
     
     func testAdminPageWithErrors() throws {
         let expectedError = "You cannot delete yourself!"
-        let _ = try viewFactory.createBlogAdminView(errors: [expectedError])
+        let _ = try viewFactory.createBlogAdminView(errors: [expectedError], user: TestDataBuilder.anyUser())
         XCTAssertEqual(viewRenderer.capturedContext?["errors"]?.array?.first?.string, expectedError)
     }
     

--- a/Tests/SteamPressTests/LeafViewFactoryTests.swift
+++ b/Tests/SteamPressTests/LeafViewFactoryTests.swift
@@ -554,7 +554,8 @@ class LeafViewFactoryTests: XCTestCase {
     }
     
     func testCreateUserViewGetsCorrectParameters() throws {
-        let _ = try viewFactory.createUserView()
+        let user = TestDataBuilder.anyUser()
+        let _ = try viewFactory.createUserView(loggedInUser: user)
         XCTAssertFalse((viewRenderer.capturedContext?["name_error"]?.bool) ?? true)
         XCTAssertFalse((viewRenderer.capturedContext?["username_error"]?.bool) ?? true)
         XCTAssertNil(viewRenderer.capturedContext?["errors"])
@@ -570,11 +571,13 @@ class LeafViewFactoryTests: XCTestCase {
         XCTAssertNil(viewRenderer.capturedContext?["biography_supplied"])
         XCTAssertNil(viewRenderer.capturedContext?["tagline_supplied"])
         XCTAssertEqual(viewRenderer.leafPath, "blog/admin/createUser")
+        XCTAssertEqual(viewRenderer.capturedContext?["user"]?["name"]?.string, user.name)
     }
     
     func testCreateUserViewWhenErrors() throws {
+        let user = TestDataBuilder.anyUser()
         let expectedError = "Not valid password"
-        let _ = try viewFactory.createUserView(errors: [expectedError], name: "Luke", username: "luke", passwordError: true, confirmPasswordError: true, resetPasswordRequired: true, profilePicture: "https://static.brokenhands.io/steampress/images/authors/luke.png", twitterHandle: "luke", biography: "The last Jedi in the Galaxy", tagline: "A son without a father")
+        let _ = try viewFactory.createUserView(errors: [expectedError], name: "Luke", username: "luke", passwordError: true, confirmPasswordError: true, resetPasswordRequired: true, profilePicture: "https://static.brokenhands.io/steampress/images/authors/luke.png", twitterHandle: "luke", biography: "The last Jedi in the Galaxy", tagline: "A son without a father", loggedInUser: user)
         XCTAssertFalse((viewRenderer.capturedContext?["name_error"]?.bool) ?? true)
         XCTAssertFalse((viewRenderer.capturedContext?["username_error"]?.bool) ?? true)
         XCTAssertEqual(viewRenderer.capturedContext?["errors"]?.array?.first?.string, expectedError)
@@ -587,17 +590,21 @@ class LeafViewFactoryTests: XCTestCase {
         XCTAssertEqual(viewRenderer.capturedContext?["twitter_handle_supplied"]?.string, "luke")
         XCTAssertEqual(viewRenderer.capturedContext?["tagline_supplied"]?.string, "A son without a father")
         XCTAssertEqual(viewRenderer.capturedContext?["biography_supplied"]?.string, "The last Jedi in the Galaxy")
+        XCTAssertEqual(viewRenderer.capturedContext?["user"]?["name"]?.string, user.name)
     }
     
     func testCreateUserViewWhenNoNameOrUsernameSupplied() throws {
+        let user = TestDataBuilder.anyUser()
         let expectedError = "No name supplied"
-        let _ = try viewFactory.createUserView(errors: [expectedError], name: nil, username: nil, passwordError: true, confirmPasswordError: true, resetPasswordRequired: true)
+        let _ = try viewFactory.createUserView(errors: [expectedError], name: nil, username: nil, passwordError: true, confirmPasswordError: true, resetPasswordRequired: true, loggedInUser: user)
         XCTAssertTrue((viewRenderer.capturedContext?["name_error"]?.bool) ?? false)
         XCTAssertTrue((viewRenderer.capturedContext?["username_error"]?.bool) ?? false)
+        XCTAssertEqual(viewRenderer.capturedContext?["user"]?["name"]?.string, user.name)
     }
     
     func testCreateUserViewForEditing() throws {
-        let _ = try viewFactory.createUserView(editing: true, errors: nil, name: "Luke", username: "luke", userId: Identifier(StructuredData.number(1), in: nil), profilePicture: "https://static.brokenhands.io/steampress/images/authors/luke.png", twitterHandle: "luke", biography: "The last Jedi in the Galaxy", tagline: "A son without a father")
+        let user = TestDataBuilder.anyUser()
+        let _ = try viewFactory.createUserView(editing: true, errors: nil, name: "Luke", username: "luke", userId: Identifier(StructuredData.number(1), in: nil), profilePicture: "https://static.brokenhands.io/steampress/images/authors/luke.png", twitterHandle: "luke", biography: "The last Jedi in the Galaxy", tagline: "A son without a father", loggedInUser: user)
         XCTAssertEqual(viewRenderer.capturedContext?["name_supplied"]?.string, "Luke")
         XCTAssertEqual(viewRenderer.capturedContext?["username_supplied"]?.string, "luke")
         XCTAssertTrue((viewRenderer.capturedContext?["editing"]?.bool) ?? false)
@@ -607,12 +614,13 @@ class LeafViewFactoryTests: XCTestCase {
         XCTAssertEqual(viewRenderer.capturedContext?["tagline_supplied"]?.string, "A son without a father")
         XCTAssertEqual(viewRenderer.capturedContext?["biography_supplied"]?.string, "The last Jedi in the Galaxy")
         XCTAssertEqual(viewRenderer.leafPath, "blog/admin/createUser")
+        XCTAssertEqual(viewRenderer.capturedContext?["user"]?["name"]?.string, user.name)
     }
     
     func testCreateUserViewThrowsWhenTryingToEditWithoutUserId() throws {
         var errored = false
         do {
-            let _ = try viewFactory.createUserView(editing: true, errors: nil, name: "Luke", username: "luke", userId: nil)
+            let _ = try viewFactory.createUserView(editing: true, errors: nil, name: "Luke", username: "luke", userId: nil, loggedInUser: TestDataBuilder.anyUser())
         } catch {
             errored = true
         }


### PR DESCRIPTION
This should simplify some of the Leaf views by ensuring there is always a user passed to a page if ones is logged in

- [x] Admin page
- [x] Create post page
- [x] Edit post page
- [x] Create user page
- [x] Edit user page
- [x] Reset password page
- [x] README