### PR TITLE
No longer mandate password complexity

### DIFF
--- a/Sources/SteamPress/Validators/Password.swift
+++ b/Sources/SteamPress/Validators/Password.swift
@@ -7,25 +7,5 @@ struct PasswordValidator: Validator {
         if input.count < 8 {
             throw error("Password not long enough")
         }
-
-        // Check complexity
-        let upperCasePattern = "^(?=.*[A-Z]).*$"
-        let lowerCasePattern = "^(?=.*[a-z]).*$"
-        let numberPattern = "^(?=.*[0-9]).*$"
-        let symbolPattern = "^(?=.*[!@#%&-_=:;\"'<>,`~\\*\\?\\+\\[\\]\\(\\)\\{\\}\\^\\$\\|\\\\\\.\\/]).*$"
-
-        let patterns = [upperCasePattern, lowerCasePattern, numberPattern, symbolPattern]
-
-        var complexityStrength = 0
-
-        for pattern in patterns {
-            if input.range(of: pattern, options: .regularExpression) != nil {
-                complexityStrength += 1
-            }
-        }
-
-        if complexityStrength < 3 {
-            throw error("Password is not complex enough")
-        }
     }
 }

--- a/Tests/SteamPressTests/BlogAdminControllerTests.swift
+++ b/Tests/SteamPressTests/BlogAdminControllerTests.swift
@@ -37,7 +37,6 @@ class BlogAdminControllerTests: XCTestCase {
         ("testCannotDeleteSelf", testCannotDeleteSelf),
         ("testCannotDeleteLastUser", testCannotDeleteLastUser),
         ("testUserCannotResetPasswordWithMismatchingPasswords", testUserCannotResetPasswordWithMismatchingPasswords),
-        ("testUserCannotResetPasswordWithBasicPassword", testUserCannotResetPasswordWithBasicPassword),
         ("testUserCanResetPassword", testUserCanResetPassword),
         ("testUserCannotResetPasswordWithoutPassword", testUserCannotResetPasswordWithoutPassword),
         ("testUserCannotResetPasswordWithoutConfirmPassword", testUserCannotResetPasswordWithoutConfirmPassword),
@@ -349,22 +348,6 @@ class BlogAdminControllerTests: XCTestCase {
         XCTAssertTrue(capturingViewFactory.resetPasswordErrors?.contains("Your passwords must match!") ?? false)
     }
     
-    func testUserCannotResetPasswordWithBasicPassword() throws {
-        let user = TestDataBuilder.anyUser()
-        try user.save()
-        
-        let request = try createLoggedInRequest(method: .post, path: "resetPassword", for: user)
-        let resetPasswordData = try Node(node: [
-            "inputPassword": "simplepassword",
-            "inputConfirmPassword": "simplepassword"
-            ])
-        request.formURLEncoded = resetPasswordData
-        
-        _ = try drop.respond(to: request)
-        
-        XCTAssertTrue(capturingViewFactory.resetPasswordErrors?.contains("Your password must contain a lowercase letter, an upperacase letter, a number and a symbol") ?? false)
-    }
-    
     func testUserCanResetPassword() throws {
         BlogUser.passwordHasher = FakePasswordHasher()
         let user = TestDataBuilder.anyUser()
@@ -421,8 +404,8 @@ class BlogAdminControllerTests: XCTestCase {
         
         let request = try createLoggedInRequest(method: .post, path: "resetPassword", for: user)
         let resetPasswordData = try Node(node: [
-            "inputPassword": "S12$",
-            "inputConfirmPassword": "S12$"
+            "inputPassword": "S12$345",
+            "inputConfirmPassword": "S12$345"
             ])
         request.formURLEncoded = resetPasswordData
         


### PR DESCRIPTION
https://www.troyhunt.com/passwords-evolved-authentication-guidance-for-the-modern-era/

Modernise the password complexity algorithm - i.e. make sure users don't have a short password. Other than that, it should be up to them, though password managers should be encouraged!