### PR TITLE
fix preparation revert function.

### DIFF
--- a/Sources/SteamPress/Models/Preparations.swift
+++ b/Sources/SteamPress/Models/Preparations.swift
@@ -121,7 +121,7 @@ struct BlogIndexes: Preparation {
     
     static func revert(_ database: Database) throws {
         try database.deleteIndex(BlogPost.Properties.slugUrl, for: BlogPost.self)
-        try database.deleteIndex(BlogUser.Properties.userID, for: BlogUser.self)
+        try database.deleteIndex(BlogUser.Properties.username, for: BlogUser.self)
         try database.deleteIndex(BlogTag.Properties.name, for: BlogTag.self)
     }
 }


### PR DESCRIPTION
BlogIndexes couldn't be revert cause delete wrong Index.


When I run `vapor run prepare revert` and it will log
```
Are you sure you want to revert batch 4 (BlogIndexes, BlogAdminUser, BlogUserExtraInformation, BlogPostDraft, Pivot<BlogPost, BlogTag>, BlogTag, BlogPost, BlogUser)?
y/n> y
[2017-12-18 23:32:24 +0000] SELECT COUNT(*) as _fluent_aggregate FROM "fluent"
[2017-12-18 23:32:24 +0000] SELECT "fluent".* FROM "fluent" ORDER BY "fluent"."batch" DESC LIMIT 1 OFFSET 0
[2017-12-18 23:32:24 +0000] SELECT "fluent".* FROM "fluent" WHERE "fluent"."name" = $1 LIMIT 1 OFFSET 0 [BlogIndexes]
[2017-12-18 23:32:24 +0000] DROP INDEX "_fluent_idx_slug_url"
[2017-12-18 23:32:24 +0000] DROP INDEX "_fluent_idx_id"
fatal error: Error raised at top level: PostgreSQL Error: ERROR:  index "_fluent_idx_id" does not exist
```