### PR TITLE
Remove admin user

### DIFF
--- a/Sources/SteamPress/Extensions/String+Random.swift
+++ b/Sources/SteamPress/Extensions/String+Random.swift
@@ -1,7 +1,7 @@
 import Crypto
 
 extension String {
-    static func random(length: Int = 12) throws  -> String {
+    public static func random(length: Int = 12) throws  -> String {
         let randomData = try CryptoRandom().generateData(count: length)
         let randomString = randomData.base64EncodedString()
         return randomString

--- a/Sources/SteamPress/Provider.swift
+++ b/Sources/SteamPress/Provider.swift
@@ -84,22 +84,9 @@ public struct Provider: Vapor.Provider {
         try sessionedRoutes.register(collection: blogAdminController)
         return .done(on: container)
     }
-
+    
     public func didBoot(_ container: Container) throws -> EventLoopFuture<Void> {
-        let userRepository = try container.make(BlogUserRepository.self)
-        return userRepository.getAllUsers(on: container).flatMap { users in
-            if users.count == 0 {
-                let passwordHasher = try container.make(PasswordHasher.self)
-                let password = try String.random()
-                let logger = try container.make(Logger.self)
-                logger.info("Admin's password is \(password)")
-                let passwordHash = try passwordHasher.hash(password)
-                let adminUser = BlogUser(name: "Admin", username: "admin", password: passwordHash, profilePicture: nil, twitterHandle: nil, biography: nil, tagline: nil)
-                return userRepository.save(adminUser, on: container).transform(to: ())
-            } else {
-                return .done(on: container)
-            }
-        }
+        return .done(on: container)
     }
 
 }

--- a/Tests/SteamPressTests/AdminTests/AdminPageTests.swift
+++ b/Tests/SteamPressTests/AdminTests/AdminPageTests.swift
@@ -17,7 +17,7 @@ class AdminPageTests: XCTestCase {
         XCTAssertEqual(presenter.adminViewPosts?.count, 2)
         XCTAssertEqual(presenter.adminViewPosts?.first?.title, testData2.post.title)
         XCTAssertEqual(presenter.adminViewPosts?.last?.title, testData1.post.title)
-        XCTAssertEqual(presenter.adminViewUsers?.count, 2)
+        XCTAssertEqual(presenter.adminViewUsers?.count, 1)
         XCTAssertEqual(presenter.adminViewUsers?.last?.username, user.username)
         
         XCTAssertEqual(presenter.adminViewPageInformation?.loggedInUser.username, user.username)

--- a/Tests/SteamPressTests/AdminTests/AdminPostTests.swift
+++ b/Tests/SteamPressTests/AdminTests/AdminPostTests.swift
@@ -535,6 +535,12 @@ class AdminPostTests: XCTestCase {
         let post = try createPostViaRequest(title: title)
         XCTAssertEqual(expectedSlugUrl, post.slugUrl)
     }
+    
+    func testRandomStringHelperDoesntProduceTheSameStringKinda() throws {
+        let string1 = try String.random()
+        let string2 = try String.random()
+        XCTAssertNotEqual(string1, string2)
+    }
 
     // MARK: - Helpers
 

--- a/Tests/SteamPressTests/AdminTests/AdminUserTests.swift
+++ b/Tests/SteamPressTests/AdminTests/AdminUserTests.swift
@@ -67,8 +67,8 @@ class AdminUserTests: XCTestCase {
         let createData = CreateUserData()
         let response = try testWorld.getResponse(to: createUserPath, body: createData, loggedInUser: user)
 
-        // First is admin user, next is user created in setup, final is one just created
-        XCTAssertEqual(testWorld.context.repository.users.count, 3)
+        // First is user created in setup, final is one just created
+        XCTAssertEqual(testWorld.context.repository.users.count, 2)
         let user = try XCTUnwrap(testWorld.context.repository.users.last)
         XCTAssertEqual(user.username, createData.username)
         XCTAssertEqual(user.name, createData.name)
@@ -141,8 +141,10 @@ class AdminUserTests: XCTestCase {
             let name = "Luke"
             let password = "password"
             let confirmPassword = "password"
-            let username = "admin"
+            let username = "lukes"
         }
+        
+        _ = testWorld.createUser(username: "lukes")
 
         let createData = CreateUserData()
         _ = try testWorld.getResponse(to: createUserPath, body: createData, loggedInUser: user)
@@ -159,8 +161,10 @@ class AdminUserTests: XCTestCase {
             let name = "Luke"
             let password = "password"
             let confirmPassword = "password"
-            let username = "Admin"
+            let username = "Lukes"
         }
+        
+        _ = testWorld.createUser(username: "lukes")
 
         let createData = CreateUserData()
         _ = try testWorld.getResponse(to: createUserPath, body: createData, loggedInUser: user)
@@ -373,7 +377,7 @@ class AdminUserTests: XCTestCase {
         let editData = EditUserData()
         let response = try testWorld.getResponse(to: "/admin/users/\(user.userID!)/edit", body: editData, loggedInUser: user)
 
-        XCTAssertEqual(testWorld.context.repository.users.count, 2)
+        XCTAssertEqual(testWorld.context.repository.users.count, 1)
         let updatedUser = try XCTUnwrap(testWorld.context.repository.users.last)
         XCTAssertEqual(updatedUser.username, editData.username)
         XCTAssertEqual(updatedUser.name, editData.name)
@@ -396,7 +400,7 @@ class AdminUserTests: XCTestCase {
         let editData = EditUserData()
         let response = try testWorld.getResponse(to: "/admin/users/\(user.userID!)/edit", body: editData, loggedInUser: user)
 
-        XCTAssertEqual(testWorld.context.repository.users.count, 2)
+        XCTAssertEqual(testWorld.context.repository.users.count, 1)
         let updatedUser = try XCTUnwrap(testWorld.context.repository.users.last)
         XCTAssertEqual(updatedUser.username, editData.username)
         XCTAssertEqual(updatedUser.name, editData.name)
@@ -420,7 +424,7 @@ class AdminUserTests: XCTestCase {
         let editData = EditUserData()
         let response = try testWorld.getResponse(to: "/admin/users/\(user.userID!)/edit", body: editData, loggedInUser: user)
 
-        XCTAssertEqual(testWorld.context.repository.users.count, 2)
+        XCTAssertEqual(testWorld.context.repository.users.count, 1)
         let updatedUser = try XCTUnwrap(testWorld.context.repository.users.last)
         XCTAssertTrue(updatedUser.resetPasswordRequired)
         XCTAssertEqual(updatedUser.userID, user.userID)
@@ -439,7 +443,7 @@ class AdminUserTests: XCTestCase {
         let editData = EditUserData()
         let response = try testWorld.getResponse(to: "/admin/users/\(user.userID!)/edit", body: editData, loggedInUser: user)
 
-        XCTAssertEqual(testWorld.context.repository.users.count, 2)
+        XCTAssertEqual(testWorld.context.repository.users.count, 1)
         let updatedUser = try XCTUnwrap(testWorld.context.repository.users.last)
         XCTAssertFalse(updatedUser.resetPasswordRequired)
         XCTAssertEqual(updatedUser.userID, user.userID)
@@ -459,7 +463,7 @@ class AdminUserTests: XCTestCase {
         let editData = EditUserData()
         let response = try testWorld.getResponse(to: "/admin/users/\(user.userID!)/edit", body: editData, loggedInUser: user)
 
-        XCTAssertEqual(testWorld.context.repository.users.count, 2)
+        XCTAssertEqual(testWorld.context.repository.users.count, 1)
         let updatedUser = try XCTUnwrap(testWorld.context.repository.users.last)
         XCTAssertEqual(updatedUser.password, editData.password)
         XCTAssertEqual(updatedUser.userID, user.userID)
@@ -595,7 +599,7 @@ class AdminUserTests: XCTestCase {
 
         XCTAssertEqual(response.http.status, .seeOther)
         XCTAssertEqual(response.http.headers[.location].first, "/admin/")
-        XCTAssertEqual(testWorld.context.repository.users.count, 2)
+        XCTAssertEqual(testWorld.context.repository.users.count, 1)
         XCTAssertNotEqual(testWorld.context.repository.users.last?.name, "Han")
     }
 
@@ -607,17 +611,17 @@ class AdminUserTests: XCTestCase {
 
         let viewErrors = try XCTUnwrap(presenter.adminViewErrors)
         XCTAssertTrue(viewErrors.contains("You cannot delete yourself whilst logged in"))
-        XCTAssertEqual(testWorld.context.repository.users.count, 3)
+        XCTAssertEqual(testWorld.context.repository.users.count, 2)
         
         XCTAssertEqual(presenter.adminViewPosts?.count, 1)
         XCTAssertEqual(presenter.adminViewPosts?.first?.title, testData.post.title)
-        XCTAssertEqual(presenter.adminViewUsers?.count, 3)
+        XCTAssertEqual(presenter.adminViewUsers?.count, 2)
         XCTAssertEqual(presenter.adminViewUsers?.last?.username, user2.username)
     }
 
     func testCannotDeleteLastUser() throws {
         testWorld = try TestWorld.create()
-        let adminUser = try XCTUnwrap(testWorld.context.repository.users.first)
+        let adminUser = testWorld.createUser(name: "Admin", username: "admin")
         let testData = try testWorld.createPost(author: adminUser)
         _ = try testWorld.getResponse(to: "/admin/users/\(adminUser.userID!)/delete", body: EmptyContent(), loggedInUser: adminUser)
 

--- a/Tests/SteamPressTests/AdminTests/LoginTests.swift
+++ b/Tests/SteamPressTests/AdminTests/LoginTests.swift
@@ -80,11 +80,6 @@ class LoginTests: XCTestCase {
         let loginWarning = try XCTUnwrap(blogPresenter.loginWarning)
         XCTAssertTrue(loginWarning)
     }
-
-    func testAdminUserCreatedOnFirstBootIfSpecified() throws {
-        testWorld = try TestWorld.create()
-        XCTAssertEqual(testWorld.context.repository.users.count, 1)
-    }
     
     func testPresenterGetsCorrectInformationForResetPasswordPage() throws {
         _ = try testWorld.getResponse(to: "/blog/admin/resetPassword", loggedInUser: user)

--- a/Tests/SteamPressTests/BlogTests/AuthorTests.swift
+++ b/Tests/SteamPressTests/BlogTests/AuthorTests.swift
@@ -36,7 +36,7 @@ class AuthorTests: XCTestCase {
         _ = try testWorld.createPost(author: newAuthor)
         _ = try testWorld.getResponse(to: allAuthorsRequestPath)
 
-        XCTAssertEqual(presenter.allAuthors?.count, 3)
+        XCTAssertEqual(presenter.allAuthors?.count, 2)
         XCTAssertEqual(presenter.allAuthorsPostCount?[newAuthor.userID!], 2)
         XCTAssertEqual(presenter.allAuthorsPostCount?[user.userID!], 1)
         XCTAssertEqual(presenter.allAuthors?.last?.name, user.name)

--- a/Tests/SteamPressTests/BlogTests/IndexTests.swift
+++ b/Tests/SteamPressTests/BlogTests/IndexTests.swift
@@ -120,9 +120,8 @@ class IndexTests: XCTestCase {
     }
     
     func testIndexPageInformationGetsLoggedInUser() throws {
-        let user = testWorld.createUser()
-        _ = try testWorld.getResponse(to: blogIndexPath, loggedInUser: user)
-        XCTAssertEqual(presenter.indexPageInformation?.loggedInUser?.username, user.username)
+        _ = try testWorld.getResponse(to: blogIndexPath, loggedInUser: firstData.author)
+        XCTAssertEqual(presenter.indexPageInformation?.loggedInUser?.username, firstData.author.username)
     }
     
     func testSettingEnvVarsWithPageInformation() throws {

--- a/Tests/SteamPressTests/BlogTests/PostTests.swift
+++ b/Tests/SteamPressTests/BlogTests/PostTests.swift
@@ -47,9 +47,8 @@ class PostTests: XCTestCase {
     }
     
     func testPostPageInformationGetsLoggedInUser() throws {
-        let user = testWorld.createUser()
-        _ = try testWorld.getResponse(to: blogPostPath, loggedInUser: user)
-        XCTAssertEqual(presenter.postPageInformation?.loggedInUser?.username, user.username)
+        _ = try testWorld.getResponse(to: blogPostPath, loggedInUser: firstData.author)
+        XCTAssertEqual(presenter.postPageInformation?.loggedInUser?.username, firstData.author.username)
     }
     
     func testSettingEnvVarsWithPageInformation() throws {

--- a/Tests/SteamPressTests/BlogTests/SearchTests.swift
+++ b/Tests/SteamPressTests/BlogTests/SearchTests.swift
@@ -61,9 +61,8 @@ class SearchTests: XCTestCase {
     }
     
     func testPageInformationGetsLoggedInUserForSearch() throws {
-        let user = testWorld.createUser()
-        _ = try testWorld.getResponse(to: "/search?term=Test", loggedInUser: user)
-        XCTAssertEqual(presenter.searchPageInformation?.loggedInUser?.username, user.username)
+        _ = try testWorld.getResponse(to: "/search?term=Test", loggedInUser: firstData.author)
+        XCTAssertEqual(presenter.searchPageInformation?.loggedInUser?.username, firstData.author.username)
     }
     
     func testSettingEnvVarsWithPageInformationForSearch() throws {

--- a/Tests/SteamPressTests/BlogTests/TagTests.swift
+++ b/Tests/SteamPressTests/BlogTests/TagTests.swift
@@ -91,9 +91,8 @@ class TagTests: XCTestCase {
     }
     
     func testTagPageInformationGetsLoggedInUser() throws {
-        let user = testWorld.createUser()
-        _ = try testWorld.getResponse(to: tagRequestPath, loggedInUser: user)
-        XCTAssertEqual(presenter.tagPageInformation?.loggedInUser?.username, user.username)
+        _ = try testWorld.getResponse(to: tagRequestPath, loggedInUser: postData.author)
+        XCTAssertEqual(presenter.tagPageInformation?.loggedInUser?.username, postData.author.username)
     }
     
     func testSettingEnvVarsWithPageInformation() throws {
@@ -120,9 +119,8 @@ class TagTests: XCTestCase {
     }
     
     func testPageInformationGetsLoggedInUserForAllTags() throws {
-        let user = testWorld.createUser()
-        _ = try testWorld.getResponse(to: allTagsRequestPath, loggedInUser: user)
-        XCTAssertEqual(presenter.allTagsPageInformation?.loggedInUser?.username, user.username)
+        _ = try testWorld.getResponse(to: allTagsRequestPath, loggedInUser: postData.author)
+        XCTAssertEqual(presenter.allTagsPageInformation?.loggedInUser?.username, postData.author.username)
     }
     
     func testSettingEnvVarsWithPageInformationForAllTags() throws {


### PR DESCRIPTION
Admin user will need to be created by the DB in migrations due to the way the provider boots up (migrations aren't run when `didBoot` is called). 